### PR TITLE
changed MeqParAngle node to use position angle relative to zentih

### DIFF
--- a/MeqNodes/src/ParAngle.cc
+++ b/MeqNodes/src/ParAngle.cc
@@ -158,18 +158,32 @@ void ParAngle::evaluateTensors (std::vector<Vells> & out,
   MEpoch mepoch(qepoch, MEpoch::UTC);
   Frame.set (mepoch);
 
-  // create Parallactic Angle machine
-  ParAngleMachine pam(sourceDir);
-  pam.set(Frame);
-//  pam.setInterval(0.04);
-  pam.setInterval(0);
+  MVDirection mvzenith(0,M_PI/2);
+
   for( int i=0; i<ntime; i++) 
   {
-    qepoch.setValue (time(i));
-//    mepoch.set (qepoch);
-//    Frame.set (mepoch);
-    ParAng[i] = pam(qepoch).get("rad").getValue();
+    qepoch.setValue(time(i));
+    mepoch.set(qepoch);
+    Frame.set(mepoch);
+    MDirection mzenith(mvzenith,MDirection::Ref(MDirection::AZEL,Frame));
+    MVDirection zenith_radec = MDirection::Convert(mzenith,MDirection::J2000)().getValue();
+    ParAng[i] = sourceCoord.positionAngle(zenith_radec);
   }
+
+
+
+//   // create Parallactic Angle machine
+//   ParAngleMachine pam(sourceDir);
+//   pam.set(Frame);
+// //  pam.setInterval(0.04);
+//   pam.setInterval(0);
+//   for( int i=0; i<ntime; i++) 
+//   {
+//     qepoch.setValue (time(i));
+// //    mepoch.set (qepoch);
+// //    Frame.set (mepoch);
+//     ParAng[i] = pam(qepoch).get("rad").getValue();
+//   }
 }
 
 } // namespace Meq

--- a/MeqServer/src/meqkernel.py
+++ b/MeqServer/src/meqkernel.py
@@ -33,13 +33,13 @@ import os.path
 
 # this ensures that C++ symbols (RTTI, DMI registries, etc.) are
 # shared across dynamically-loaded modules
-
+# this ensures that C++ symbols (RTTI, DMI registries, etc.) are
+# shared across dynamically-loaded modules
 try:
   import dl
 except:
   import DLFCN
   dl = DLFCN
-
 sys.setdlopenflags(dl.RTLD_NOW | dl.RTLD_GLOBAL);
 
 # sys.argv is not present when embedding a Python interpreter, but some

--- a/OCTOPython/src/dmi.py
+++ b/OCTOPython/src/dmi.py
@@ -30,13 +30,11 @@ import sys
 
 # this ensures that C++ symbols (RTTI, DMI registries, etc.) are
 # shared across dynamically-loaded modules
-
 try:
   import dl
 except:
   import DLFCN
   dl = DLFCN
-
 sys.setdlopenflags(dl.RTLD_NOW | dl.RTLD_GLOBAL);
 
 import string

--- a/OCTOPython/src/octopussy.py
+++ b/OCTOPython/src/octopussy.py
@@ -30,12 +30,13 @@ import sys
 # this ensures that C++ symbols (RTTI, DMI registries, etc.) are
 # shared across dynamically-loaded modules
 
+# this ensures that C++ symbols (RTTI, DMI registries, etc.) are
+# shared across dynamically-loaded modules
 try:
   import dl
 except:
   import DLFCN
   dl = DLFCN
-
 sys.setdlopenflags(dl.RTLD_NOW | dl.RTLD_GLOBAL);
 
 import Timba


### PR DESCRIPTION
The ParAngleMachine class I formerly used does some funky magic to accelerate PA computation, but this produces results somewhat different to the straightforward computation done in e.g. tigger-convert using dm.posangle(). This makes comparison and verification difficult. 