### PR TITLE
Adding cmath header to fix gcc issue with abs not being fully resolvable

### DIFF
--- a/MeqNodes/src/PSVTensor.cc
+++ b/MeqNodes/src/PSVTensor.cc
@@ -21,6 +21,7 @@
 //#
 //# $Id: PSVTensor.cc 8270 2011-07-06 12:17:23Z oms $
 
+#include <cmath>
 #include <MeqNodes/PSVTensor.h>
 #include <DMI/AID-DMI.h>
 #include <MEQ/AID-Meq.h>

--- a/MeqNodes/src/TFSmearFactor.cc
+++ b/MeqNodes/src/TFSmearFactor.cc
@@ -20,7 +20,7 @@
 //# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //#
 //# $Id: TFSmearFactor.cc 5418 2007-07-19 16:49:13Z oms $
-
+#include <cmath>
 #include <MeqNodes/TFSmearFactor.h>
 #include <casa/BasicSL/Constants.h>
 


### PR DESCRIPTION
This PR is to fix compilation issues outlined in https://github.com/ska-sa/meqtrees-timba/issues/43